### PR TITLE
feat(settings): add folder-specific settings for Rust

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,19 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "lsp": {
+    "rust-analyzer": {
+      "cargo": {
+        "features": ["ssr"]
+      },
+      "procMacro": {
+        "ignored": ["server", "component"]
+      },
+      "rustfmt": {
+        "overrideCommand": ["leptosfmt", "--stdin", "--rustfmt"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new settings file for folder-specific configurations in Zed. 
This includes settings for the Rust language server, such as 
customizing cargo features, ignoring specific procedural macros, 
and overriding the rustfmt command. These changes enhance the 
development experience by providing tailored settings for Rust 
projects.