### PR TITLE
chore: ignore build output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules/
 test-results/
 end2end/playwright-report/
 playwright/.cache/
+dist/


### PR DESCRIPTION
Add dist/ to .gitignore so generated build artifacts are not tracked. This prevents accidental commits of compiled or bundled files and keeps the repository clean. It aligns ignore rules with existing test and cache entries.