### PR TITLE
fix(styles): correct misspelled CSS property in fill styles

### DIFF
--- a/style/fill.scss
+++ b/style/fill.scss
@@ -1,15 +1,15 @@
 :has([data-fill="solid"]) {
-    colour: var(--color);
+    color: var(--color);
     background-color: var(--background_color);
 }
 
 :has([data-fill="ghost"]) {
-    colour: var(--color);
+    color: var(--color);
     background-color: transparent;
     border-color: var(--color);
 }
 
 :has([data-fill="text"]) {
-    colour: var(--color);
+    color: var(--color);
     background-color: transparent;
 }


### PR DESCRIPTION
Fix the misspelling of the color property in the fill stylesheet. Replace

"colour" with the standard CSS "color" in selectors for solid, ghost,

and text fills so the declared variables are applied correctly.



This ensures text and border colors render as intended across browsers

and aligns the code with standard CSS property names.